### PR TITLE
Add subagent stop call hook for logging

### DIFF
--- a/subagent_stop_call.rb
+++ b/subagent_stop_call.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'fileutils'
+
+# Read JSON from STDIN
+input = STDIN.read
+data = JSON.parse(input)
+
+# Extract required fields
+session_id = data['session_id']
+cwd = data['cwd']
+
+# Change directory to the cwd
+Dir.chdir(cwd)
+
+# Ensure .git directory exists
+git_dir = File.join(cwd, '.git')
+exit 1 unless Dir.exist?(git_dir)
+
+# Create log entry with timestamp
+log_entry = {
+  timestamp: Time.now.iso8601,
+  session_id: session_id,
+  event: 'subagent_stop',
+  data: data
+}
+
+# Append to .git/subagent.jsonl
+log_file = File.join(git_dir, 'subagent.jsonl')
+File.open(log_file, 'a') do |file|
+  file.puts(log_entry.to_json)
+end


### PR DESCRIPTION
## Summary
- Add new `subagent_stop_call.rb` hook that captures subagent stop events
- Logs event data with timestamps to `.git/subagent.jsonl` file
- Follows same pattern as existing hooks for consistency

## Test plan
- [ ] Verify hook executes when subagent stops
- [ ] Confirm data is properly logged to `.git/subagent.jsonl`
- [ ] Test hook doesn't interfere with normal subagent operation

🤖 Generated with [Claude Code](https://claude.ai/code)